### PR TITLE
Add a newline when printing `infuse` object

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -43,5 +43,5 @@ print_requested_params<-function(params_requested){
 #' @param ... further arguments passed to or from other methods.
 #' @export
 print.infuse<-function(x, ...){
-  cat(x)
+  cat(x, "\n")
 }


### PR DESCRIPTION
Otherwise printing on Linux will result in the prompt added just after the value, not in a new line.

On Windows, adding "\n" does not change the output (with as well as without adds a new line for the prompt)